### PR TITLE
make flexboxgrid generate code via function call from parenting appli…

### DIFF
--- a/flexboxgrid.less
+++ b/flexboxgrid.less
@@ -2,17 +2,6 @@
 @import "variables.less"; //can't seem to override variables in Hubrick LESS
 @import "mixins.less";
 
-//default breakpoints
-@xl-break: 1675px;
-@l-break: 1300px;
-@m-break: 985px;
-@s-break: 650px;
-
-//default sizings
-@col-names: sm, md, lg;
-@col-breaks: @s-break, @m-break, @l-break;
-
-
 .grid {
   padding-right: @outer-margin;
   padding-left: @outer-margin;
@@ -33,11 +22,23 @@
    .col-reverse();
 }
 
-.makegrid(xs);
+.flexboxgrid(@sb, @mb, @lb, @xlb) {
+  @xl-break: @xlb;
+  @l-break: @lb;
+  @m-break: @mb;
+  @s-break: @sb;
 
-.for-each(@col-breaks);
-.-each(@breakpoint) {
-  @media only screen and (min-width: @breakpoint) {
-    .makegrid(extract(@col-names, @i));
+  //default sizings
+  @col-names: sm, md, lg;
+  @col-breaks: @s-break, @m-break, @l-break;
+
+  .makegrid(xs);
+
+  .for-each(@col-breaks);
+  .-each(@breakpoint) {
+    @media only screen and (min-width: @breakpoint) {
+      .makegrid(extract(@col-names, @i));
+    }
   }
 }
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {  
   "name": "flexboxgrid-less",
-  "version": "1.0.5",
+  "version": "1.1.0",
   "description": "Less code for the gridsystem of flexboxgrid.com",
   "homepage": "https://github.com/bassjobsen/flexboxgrid-less",
   "author": {


### PR DESCRIPTION
make flexboxgrid generate code via function call from parenting application.

a parenting application will bootstrap flexboxgrid by doing something similar to:

```
@import "~node_modules/flexboxgrid-less/flexboxgrid";
@xl: 1675px;
@l: 1300px;
@m: 985px;
@s: 650px;

.flexboxgrid(@s, @m, @l, @xl)
```
